### PR TITLE
fix log name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: '1.3.0'
 
@@ -46,7 +46,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ matrix.terraform }}
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module "alert_lambda" {
 ```
 
 ## Requirements
-* Terraform version 1.1.9 or greater
+* Terraform version 1.3.0 or greater
 * AWS Provider 3.75.2 or greater
 * BYU-ACS version 3.5.0 or greater
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ That Alarm Data is then reformatted into the expected format that Operations is 
 ## Usage
 ```
 module "alert_lambda" {
-  source = "github.com/byu-oit/terraform-aws-alert-lambda?ref=v1.1.0"
+  source = "github.com/byu-oit/terraform-aws-alert-lambda?ref=v1.1.1"
 }
 ```
 

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -19,7 +19,7 @@ module "acs" {
 }
 
 module "alert_lambda" {
-  source                           = "../.."
+  source                           = "github.com/byu-oit/terraform-aws-alert-lambda?ref=v1.1.1"
   app_name                         = "my-app-dev"
   monitoring_host                  = "https://in.monitoringdev.byu.edu/"
   kb                               = "KB000000"

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_lambda_function" "sns_to_operations" {
 }
 
 resource "aws_cloudwatch_log_group" "logging" {
-  name              = "/aws/lambda/${var.app_name}/${local.module_name}"
+  name              = "/aws/lambda/${var.app_name}-${local.module_name}"
   retention_in_days = var.log_retention_in_days
 }
 


### PR DESCRIPTION
- Bump hashicorp/setup-terraform from 2 to 3
- log group name has to match lambda name

For anything previously deployed, this will be a weird breaking change.
`terraform apply` will probably fail to create the new log group because
it already exists (the Lambda would have created it). If this happens to
you, the solution is to use `terraform import` to link the correctly
named log group in your terraform project's state file. Alternatively,
you could delete the log group and let terraform create it, but this
will be a race against any Lambda invocations.

